### PR TITLE
Update insecure_repository patch

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -142,13 +142,10 @@ http_archive(
 
 ## DOCKER RULES
 
-# TODO: use a release newer than v0.25.0. We need insecure registry support, so we use git_repository().  
-# Restore http_archive() when a new release is available.
-# FMI: https://github.com/bazelbuild/rules_docker/pull/1403
-git_repository(
+http_archive(
     name = "io_bazel_rules_docker",
-    commit = "704d3a55701ae6719326f49018e15fd8ae230cc4",
-    remote = "https://github.com/bazelbuild/rules_docker",
+    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
 )
 
 load(

--- a/bazel/pipeline.bzl
+++ b/bazel/pipeline.bzl
@@ -25,7 +25,7 @@ def sematic_pipeline(
         image_layers = None,
         image_tags = None,
         env = None,
-        insecure_repository = False,
+        insecure_repository = None,
         dev = False):
     """
     A Bazel rule to run a Sematic pipeline.
@@ -64,7 +64,9 @@ def sematic_pipeline(
 
         env: (optional) mapping of environment variables to set in the container
 
-        insecure_repository: (optional) whether the repository is insecure (i.e. http not https)
+        insecure_repository: (optional) Whether the repository is insecure (i.e. http not https).
+            Should only be used if your rules_docker is at a version newer than v0.25.0.
+            Defaults to `None`, which will fall back to 
 
         dev: (optional) For Sematic dev only. switch between using worker in the installed
         wheel or in the current repo.
@@ -144,6 +146,9 @@ def sematic_pipeline(
 
         push_rule_name = "{}_{}_push".format(name, tag)
         push_rule_names[tag] = [push_rule_name, "{}/{}".format(registry, repository)]
+        extra_push_kwargs = {}
+        if insecure_repository == None:
+            extra_push_kwargs["insecure_repository"] = insecure_repository
 
         container_push(
             name = push_rule_name,
@@ -153,7 +158,7 @@ def sematic_pipeline(
             tag = "{}_{}".format(name, tag),
             format = "Docker",
             tags = tags,
-            insecure_repository = insecure_repository,
+            **extra_push_kwargs,
         )
     
     py_binary(

--- a/bazel/pipeline.bzl
+++ b/bazel/pipeline.bzl
@@ -66,7 +66,8 @@ def sematic_pipeline(
 
         insecure_repository: (optional) Whether the repository is insecure (i.e. http not https).
             Should only be used if your rules_docker is at a version newer than v0.25.0.
-            Defaults to `None`, which will fall back to 
+            Defaults to `None`, which will fall back to `container_push`'s value for this
+            parameter.
 
         dev: (optional) For Sematic dev only. switch between using worker in the installed
         wheel or in the current repo.


### PR DESCRIPTION
Make the patch compatible with users who are using older versions of rules_docker without the insecure_repository option.