### PR TITLE
Add support for custom security contexts

### DIFF
--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
 {{ end }}
   KUBERNETES_NAMESPACE: {{ .Release.Namespace }}
   SEMATIC_WORKER_KUBERNETES_SA: {{ .Values.worker.service_account.name | quote }}
-  ALLOW_CUSTOM_SECURITY_CONTEXTS: {{ can_customize_security_context }}
+  ALLOW_CUSTOM_SECURITY_CONTEXTS: {{ .Values.worker.can_customize_security_context | quote }}
   SEMATIC_WORKER_API_ADDRESS: "http://{{ .Release.Name }}"
 {{ if .Values.deployment.socket_io.dedicated }}
   SEMATIC_WORKER_SOCKET_IO_ADDRESS: {{ printf "http://%s-socketio" .Release.Name }}

--- a/helm/sematic-server/templates/configmap.yaml
+++ b/helm/sematic-server/templates/configmap.yaml
@@ -27,6 +27,7 @@ data:
 {{ end }}
   KUBERNETES_NAMESPACE: {{ .Release.Namespace }}
   SEMATIC_WORKER_KUBERNETES_SA: {{ .Values.worker.service_account.name | quote }}
+  ALLOW_CUSTOM_SECURITY_CONTEXTS: {{ can_customize_security_context }}
   SEMATIC_WORKER_API_ADDRESS: "http://{{ .Release.Name }}"
 {{ if .Values.deployment.socket_io.dedicated }}
   SEMATIC_WORKER_SOCKET_IO_ADDRESS: {{ printf "http://%s-socketio" .Release.Name }}

--- a/helm/sematic-server/values.yaml
+++ b/helm/sematic-server/values.yaml
@@ -104,6 +104,7 @@ service_account:
 worker:
   service_account:
     name: default
+  can_customize_security_context: false
 
 service:
   create: false

--- a/sematic/config/server_settings.py
+++ b/sematic/config/server_settings.py
@@ -43,6 +43,11 @@ class ServerSettingsVar(AbstractPluginSettingsVar):
     # uses for jobs.
     SEMATIC_WORKER_KUBERNETES_SA = "SEMATIC_WORKER_KUBERNETES_SA"
 
+    # Controls whether users who are defining pipelines can
+    # customize the Kubernetes security context in which their
+    # job runs.
+    ALLOW_CUSTOM_SECURITY_CONTEXTS = "ALLOW_CUSTOM_SECURITY_CONTEXTS"
+
     # GRAFANA
     GRAFANA_PANEL_URL = "GRAFANA_PANEL_URL"
 

--- a/sematic/resolvers/resource_requirements.py
+++ b/sematic/resolvers/resource_requirements.py
@@ -195,6 +195,55 @@ class KubernetesToleration:
 
 
 @dataclass
+class KubernetesCapabilities:
+    """Capabilities associated with a Kubernetes Security Context.
+
+    For more docs, see:
+    https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#capabilities-v1-core
+
+    Attributes
+    ----------
+    add:
+        Added capabilities
+    drop:
+        Dropped capabilities
+    """
+
+    add: List[str] = field(default_factory=list)
+    drop: List[str] = field(default_factory=list)
+
+
+@dataclass
+class KubernetesSecurityContext:
+    """A security context the Sematic job should run with.
+
+    Docs sourced from:
+    https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#securitycontext-v1-core
+
+    Attributes
+    ----------
+    allow_privilege_escalation:
+        AllowPrivilegeEscalation controls whether a process can gain more privileges
+        than its parent process. This bool directly controls if the no_new_privs
+        flag will be set on the container process. AllowPrivilegeEscalation is true
+        always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note
+        that this field cannot be set when spec.os.name is windows.
+    privileged:
+        Run container in privileged mode. Processes in privileged containers are
+        essentially equivalent to root on the host. Defaults to false. Note that
+        this field cannot be set when spec.os.name is windows.
+    capabilities:
+        The capabilities to add/drop when running containers. Defaults to the default
+        set of capabilities granted by the container runtime. Note that this field
+        cannot be set when spec.os.name is windows.
+    """
+
+    allow_privilege_escalation: bool
+    privileged: bool
+    capabilities: KubernetesCapabilities
+
+
+@dataclass
 class KubernetesResourceRequirements:
     """Information on the Kubernetes resources required.
 
@@ -224,9 +273,10 @@ class KubernetesResourceRequirements:
         memory-backed tmpfs that expands up to half of the available memory file is used
         instead. Defaults to False. If that file is expanded to more than that limit
         (through external action), then the pod will be terminated.
-    security_context_capabilities: List[str]
-        Run the pod in `privileged` mode with the given capabilities.  For example, if
-        you need your job to FUSE-mount a filesystem, run with 'SYS_ADMIN'.
+    security_context: Optional[KubernetesSecurityContext]
+        The Kubernetes security context the job will run with. Note that this
+        field will only be respected if ALLOW_CUSTOM_SECURITY_CONTEXTS has been
+        enabled by your Sematic administrator.
     """
 
     node_selector: Dict[str, str] = field(default_factory=dict)
@@ -234,7 +284,7 @@ class KubernetesResourceRequirements:
     secret_mounts: KubernetesSecretMount = field(default_factory=KubernetesSecretMount)
     tolerations: List[KubernetesToleration] = field(default_factory=list)
     mount_expanded_shared_memory: bool = field(default=False)
-    security_context_capabilities: List[str] = field(default_factory=list)
+    security_context: Optional[KubernetesSecurityContext] = None
 
 
 @dataclass

--- a/sematic/resolvers/tests/test_resource_requirements.py
+++ b/sematic/resolvers/tests/test_resource_requirements.py
@@ -36,7 +36,7 @@ def test_is_serializable():
                 )
             ],
             mount_expanded_shared_memory=True,
-            security_context_capabilities=['SYS_ADMIN'],
+            security_context_capabilities=["SYS_ADMIN"],
         )
     )
     encoded = value_to_json_encodable(requirements, ResourceRequirements)

--- a/sematic/scheduling/kubernetes.py
+++ b/sematic/scheduling/kubernetes.py
@@ -20,7 +20,11 @@ from urllib3.exceptions import ConnectionError
 
 # Sematic
 from sematic.config.config import KUBERNETES_POD_NAME_ENV_VAR, ON_WORKER_ENV_VAR
-from sematic.config.server_settings import ServerSettingsVar, get_server_setting
+from sematic.config.server_settings import (
+    ServerSettingsVar,
+    get_bool_server_setting,
+    get_server_setting,
+)
 from sematic.config.settings import get_plugin_setting
 from sematic.config.user_settings import UserSettingsVar
 from sematic.container_images import CONTAINER_IMAGE_ENV_VAR
@@ -552,9 +556,10 @@ def _schedule_kubernetes_job(
             volume_mounts.append(mount)
 
         if resource_requirements.kubernetes.security_context is not None:
-            if not get_server_setting(
+            allow_customization = get_bool_server_setting(
                 ServerSettingsVar.ALLOW_CUSTOM_SECURITY_CONTEXTS, False
-            ):
+            )
+            if not allow_customization:
                 raise ValueError(
                     "User tried to customize the security context for their "
                     "Sematic function, but ALLOW_CUSTOM_SECURITY_CONTEXTS is "

--- a/sematic/scheduling/tests/test_kubernetes.py
+++ b/sematic/scheduling/tests/test_kubernetes.py
@@ -88,7 +88,7 @@ def test_schedule_kubernetes_job(k8s_batch_client, mock_kube_config):
                 KubernetesToleration(),
             ],
             mount_expanded_shared_memory=True,
-            security_context_capabilities=['SYS_ADMIN'],
+            security_context_capabilities=["SYS_ADMIN"],
         )
     )
 


### PR DESCRIPTION
Adds support for custom security contexts, which can help enable things like Fuse filesystems. The feature is behind a feature flag so Sematic administrators have to explicitly opt-in to allow security context customizations.

Testing
--------
Deployed this with the feature flag enabled, and executed a run that requested privlege escalation and the SYS_ADMIN capability. Confirmed the resulting pod contained this:

```yaml
# ...
    name: sematic-worker-382144f37fcb4c2ca3b15e4a2446e260-5c935e
    resources: {}
    securityContext:
      allowPrivilegeEscalation: true
      capabilities:
        add:
        - SYS_ADMIN
      privileged: true
# ...
```

Deployed without the feature flag and confirmed the request was rejected with an appropriate error.